### PR TITLE
Store full hashes for all entries

### DIFF
--- a/src/TextMap.mo
+++ b/src/TextMap.mo
@@ -149,7 +149,7 @@ module {
       if (not contains(key)) { return };
       let hsh = djb2(key);
       var i : Nat = Nat32.toNat(hsh) % capacity;
-      while(hashes[i] != hsh and keys[i] != ?key) {
+      while(not (hashes[i] == hsh and keys[i] == ?key)) {
         i := (i + 1) % capacity;
       };
       keys[i] := null;
@@ -246,7 +246,7 @@ module {
 
   // Copied from http://www.cse.yorku.ca/~oz/hash.html.
   // This should be a little better than base's current text hash.
-  func djb2(t : Text) : Nat32 {
+  public func djb2(t : Text) : Nat32 {
     var hash : Nat32 = 5381;
     for (char in t.chars()) {
       let c : Nat32 = Char.toNat32(char);

--- a/test/Test.mo
+++ b/test/Test.mo
@@ -118,4 +118,41 @@ let deleteTests = S.suite("Deletion", [
     ),
 ]);
 
-S.run(S.suite("TextMap", [putGet, resizeTests, testMatchers, deleteTests]));
+let collisionTest = do {
+    let map = TextMap.new<Nat>();
+    // These two collide
+    map.put("hetairas", 10);
+    map.put("mentioner", 20);
+    S.suite("Collisions", [
+        S.test("insertion worked", map, TMM.containsExactly(
+            T.natTestable,
+            [("hetairas", 10), ("mentioner", 20)]
+        )),
+        S.test("simple lookup", map, TMM.containsElement("hetairas", T.nat(10))),
+        S.test("simple lookup2", map, TMM.containsElement("mentioner", T.nat(20))),
+        S.test("delete1",
+            do {
+                let myMap = map.clone();
+                myMap.delete("hetairas");
+                myMap
+            },
+            TMM.containsExactly(
+                T.natTestable,
+                [("mentioner", 20)]
+            )
+        ),
+        S.test("delete2",
+            do {
+                let myMap = map.clone();
+                myMap.delete("mentioner");
+                myMap
+            },
+            TMM.containsExactly(
+                T.natTestable,
+                [("hetairas", 10)]
+            )
+        )
+    ])
+};
+
+S.run(S.suite("TextMap", [putGet, resizeTests, testMatchers, deleteTests, collisionTest]));


### PR DESCRIPTION
This trades some extra space against being able to short-circuit comparisons when probing as well as not having to rehash when resizing.

Since we're only storing `Text` keys this seems like the right trade-off as comparing/hashing Text is expensive.